### PR TITLE
perf(zsh): optimize shell startup from ~470ms to ~100ms

### DIFF
--- a/zsh/.config/zsh/.zprofile
+++ b/zsh/.config/zsh/.zprofile
@@ -5,9 +5,12 @@ elif [[ -f /usr/local/bin/brew ]]; then
 fi
 
 if command -v gpg &>/dev/null; then
-    export GPG_TTY=$(tty)
-    gpgconf --launch gpg-agent 2>/dev/null || true
-    export SSH_AUTH_SOCK=$HOME/.gnupg/S.gpg-agent.ssh
+    [[ -t 0 ]] && export GPG_TTY=$(tty)
+    export SSH_AUTH_SOCK="$(gpgconf --list-dirs agent-ssh-socket 2>/dev/null)"
+    # Skip slow gpgconf --launch (~400ms) when agent is already healthy
+    if ! gpg-connect-agent /bye &>/dev/null; then
+        gpgconf --launch gpg-agent 2>/dev/null || true
+    fi
 fi
 
 export PATH=$HOME/bin:$HOME/.local/bin:$PATH

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -68,8 +68,30 @@ alias brewup='brew update; brew upgrade; brew cleanup; brew doctor'
 
 alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 
+# Cache a command's init output, regenerating when the binary updates
+_cached_eval() {
+    local cmd=$1
+    local cmd_path="${commands[$cmd]:-$(command -v "$cmd" 2>/dev/null)}" || return
+    shift
+    local cache_key="${cmd}__${(j:_:)@}"
+    local cache_file="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/${cache_key}.zsh"
+    if [[ ! -f "$cache_file" || "$cmd_path" -nt "$cache_file" ]]; then
+        mkdir -p "${cache_file:h}"
+        local tmp_file="${cache_file}.tmp.$$"
+        if "$cmd" "$@" > "$tmp_file" 2>/dev/null; then
+            mv "$tmp_file" "$cache_file"
+        else
+            rm -f "$tmp_file"
+            # Fallback to direct eval if caching fails
+            eval "$("$cmd" "$@")"
+            return
+        fi
+    fi
+    source "$cache_file"
+}
+
 [[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh
-command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
-command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+command -v direnv &>/dev/null && _cached_eval direnv hook zsh
+command -v zoxide &>/dev/null && _cached_eval zoxide init zsh
 zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
-command -v carapace &>/dev/null && source <(carapace _carapace)
+command -v carapace &>/dev/null && _cached_eval carapace _carapace


### PR DESCRIPTION
- Skip gpgconf --launch when agent is already healthy via gpg-connect-agent liveness check (~8ms vs ~400ms)
- Guard GPG_TTY export for real TTYs only
- Use gpgconf --list-dirs for SSH socket path instead of hardcoding
- Cache direnv/zoxide/carapace init output to files, regenerating only when the binary updates (atomic write with tmp+mv)